### PR TITLE
feat(#17): presets + post-upload styling, DOCX-intermediate update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] — 2026-04-22
+
+### Added
+- **Presets** — `--preset <name>` flag and `src/presets.ts` registry. Each preset is a declarative bundle of post-upload settings (alignment, per-`namedStyleType` text styling, optional document-wide font overrides). First preset: `legal` (justified + Open Sans; NORMAL_TEXT 11 pt; H1 20 / H2 16 / H3 14 / H4 12 / H5 11 / H6 11 pt).
+- `namedStyles` option in `ConvertOptions` and in presets — map from `namedStyleType` (`NORMAL_TEXT`, `HEADING_1`, …) to `{ fontFamily?, fontSize? }`. Keeps heading sizes intact instead of collapsing the whole document to one run style.
+- `--alignment <value>` CLI flag (and `alignment` option in `ConvertOptions`) — optional post-upload paragraph alignment. Values: `start`, `center`, `end`, `justified`, `none`.
+- `--font <family>` and `--font-size <pt>` flags (and `fontFamily` / `fontSize` options) — single-style override applied to the entire document (use sparingly; prefer `namedStyles`).
+- `applyAlignment(documentId, alignment)`, `applyTextStyle(documentId, style)`, `applyNamedStyles(documentId, map)`, and `exportAsDocx(fileId, outputPath)` executor helpers.
+
+### Changed
+- **Existing-document update (`--document-id`) now goes through a DOCX intermediate instead of HTML.** HTML re-import stripped bullet lists; DOCX preserves them.
+- Post-upload styling (alignment/font) is now opt-in via preset or explicit flags. By default mdocify leaves Drive's native conversion output untouched.
+
+### Fixed
+- Unordered markdown lists (`- item`) no longer lose bullet markers when updating an existing document (#17).
+
 ## [0.2.0] — 2026-04-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `namedStyles` option in `ConvertOptions` and in presets — map from `namedStyleType` (`NORMAL_TEXT`, `HEADING_1`, …) to `{ fontFamily?, fontSize? }`. Keeps heading sizes intact instead of collapsing the whole document to one run style.
 - `--alignment <value>` CLI flag (and `alignment` option in `ConvertOptions`) — optional post-upload paragraph alignment. Values: `start`, `center`, `end`, `justified`, `none`.
 - `--font <family>` and `--font-size <pt>` flags (and `fontFamily` / `fontSize` options) — single-style override applied to the entire document (use sparingly; prefer `namedStyles`).
-- `applyAlignment(documentId, alignment)`, `applyTextStyle(documentId, style)`, `applyNamedStyles(documentId, map)`, and `exportAsDocx(fileId, outputPath)` executor helpers.
+- `applyFormatting(documentId, opts)` and `exportAsDocx(fileId, outputPath)` executor helpers. `applyFormatting` applies alignment, per-`namedStyleType` overrides and a document-wide text style in a single `documents.get` + `batchUpdate` pass.
 
 ### Changed
 - **Existing-document update (`--document-id`) now goes through a DOCX intermediate instead of HTML.** HTML re-import stripped bullet lists; DOCX preserves them.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,55 @@ npx @oshliaer/mdocify convert <file.md>
 mdocify convert <markdown-file>
 ```
 
+Common flags:
+
+- `--document-id <id>` — update an existing document (DOCX-intermediate path preserves bullet lists)
+- `--preset <name>` — apply a named bundle of post-upload settings (e.g. `legal`, see "Presets" below)
+- `--alignment <value>` — paragraph alignment applied after upload (`start`, `center`, `end`, `justified`, `none`)
+- `--font <family>` — font family applied document-wide (e.g. `"Open Sans"`)
+- `--font-size <pt>` — font size in points
+- `--verify` — run round-trip verification after conversion
+
+Explicit flags override values provided by a preset. By default mdocify leaves Drive's native styling untouched.
+
 Requires Google Workspace authentication via `gws` CLI.
+
+## Presets
+
+Presets are named bundles of post-upload settings declared in [`src/presets.ts`](src/presets.ts). The CLI stays simple and exposes primitive flags; skills and scripts call it with a preset name instead of repeating the same flag combination.
+
+Each preset can set:
+
+- `alignment` — paragraph alignment applied to the whole body.
+- `namedStyles` — per-`namedStyleType` text styling (`NORMAL_TEXT`, `HEADING_1`, …). Prefer this over a document-wide `fontFamily`/`fontSize`: it keeps heading sizes distinct instead of collapsing everything to one run style.
+- `fontFamily` / `fontSize` — document-wide override applied as a single run style. Useful for quick-and-dirty tweaks; explicit flags win over preset values.
+
+### `legal`
+
+| Scope | Font | Size |
+|-------|------|------|
+| `NORMAL_TEXT` | Open Sans | 11 pt |
+| `HEADING_1` | Open Sans | 20 pt |
+| `HEADING_2` | Open Sans | 16 pt |
+| `HEADING_3` | Open Sans | 14 pt |
+| `HEADING_4` | Open Sans | 12 pt |
+| `HEADING_5` | Open Sans | 11 pt |
+| `HEADING_6` | Open Sans | 11 pt |
+| Alignment | `JUSTIFIED` (whole body) | |
+
+Usage:
+
+```bash
+mdocify convert contract.md --document-id <id> --preset legal
+# override a single slot
+mdocify convert contract.md --preset legal --font-size 12
+```
+
+To add a preset, extend the `PRESETS` object in `src/presets.ts` and document it here. Keep presets declarative — avoid embedding execution logic in skills or wrappers; the CLI applies the bundle itself.
+
+### Known limitation — `namedStyles` vs theme defaults
+
+Presets only style paragraphs that actually exist in the document; they do **not** mutate the document-level `namedStyles` entries themselves (the Docs API has no "update named style" request). If a `namedStyleType` has no paragraph at upload time, Google Docs keeps its built-in default when the user later switches a paragraph to that style. For stricter theming, generate the target Doc from a prepared template instead.
 
 ## Architecture
 

--- a/bin/mdocify.ts
+++ b/bin/mdocify.ts
@@ -19,11 +19,17 @@ program
   .option('--verify', 'Run round-trip verification after conversion')
   .option('-o, --output <path>', 'Path to save exported markdown (with --verify)')
   .option('-p, --preset <name>', 'Named bundle of post-upload settings (e.g. "legal")')
-  .option('-a, --alignment <value>', 'Paragraph alignment: start|center|end|justified|none')
+  .option('-a, --alignment <value>', 'Paragraph alignment: start|center|end|justified|none', (v) => {
+    const valid = ['start', 'center', 'end', 'justified', 'none'];
+    if (!valid.includes(v)) {
+      throw new Error(`Invalid --alignment "${v}": expected one of ${valid.join(', ')}`);
+    }
+    return v;
+  })
   .option('--font <family>', 'Font family (e.g. "Open Sans")')
   .option('--font-size <pt>', 'Font size in points', (v) => {
     const parsed = parseFloat(v);
-    if (Number.isNaN(parsed) || parsed <= 0) {
+    if (!Number.isFinite(parsed) || parsed <= 0) {
       throw new Error(`Invalid --font-size "${v}": expected a positive number`);
     }
     return parsed;

--- a/bin/mdocify.ts
+++ b/bin/mdocify.ts
@@ -18,13 +18,21 @@ program
   .option('-d, --document-id <id>', 'Existing document ID to update')
   .option('--verify', 'Run round-trip verification after conversion')
   .option('-o, --output <path>', 'Path to save exported markdown (with --verify)')
-  .action(async (file: string, opts: Record<string, string | boolean>) => {
+  .option('-p, --preset <name>', 'Named bundle of post-upload settings (e.g. "legal")')
+  .option('-a, --alignment <value>', 'Paragraph alignment: start|center|end|justified|none')
+  .option('--font <family>', 'Font family (e.g. "Open Sans")')
+  .option('--font-size <pt>', 'Font size in points', (v) => parseFloat(v))
+  .action(async (file: string, opts: Record<string, string | number | boolean>) => {
     try {
       const result = await convert(file, {
         title: opts.title as string | undefined,
         documentId: opts.documentId as string | undefined,
         verify: opts.verify as boolean | undefined,
         output: opts.output as string | undefined,
+        preset: opts.preset as string | undefined,
+        alignment: opts.alignment as 'start' | 'center' | 'end' | 'justified' | 'none' | undefined,
+        fontFamily: opts.font as string | undefined,
+        fontSize: opts.fontSize as number | undefined,
       });
 
       console.log(`Document created: ${result.url}`);

--- a/bin/mdocify.ts
+++ b/bin/mdocify.ts
@@ -21,7 +21,13 @@ program
   .option('-p, --preset <name>', 'Named bundle of post-upload settings (e.g. "legal")')
   .option('-a, --alignment <value>', 'Paragraph alignment: start|center|end|justified|none')
   .option('--font <family>', 'Font family (e.g. "Open Sans")')
-  .option('--font-size <pt>', 'Font size in points', (v) => parseFloat(v))
+  .option('--font-size <pt>', 'Font size in points', (v) => {
+    const parsed = parseFloat(v);
+    if (Number.isNaN(parsed) || parsed <= 0) {
+      throw new Error(`Invalid --font-size "${v}": expected a positive number`);
+    }
+    return parsed;
+  })
   .action(async (file: string, opts: Record<string, string | number | boolean>) => {
     try {
       const result = await convert(file, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oshliaer/mdocify",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Convert Markdown to Google Docs via batch API — a gws add-on",
   "type": "module",
   "bin": {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -31,6 +31,10 @@ npx mdocify convert <file> [options]
 | `--document-id` | — | — | Update existing document |
 | `--verify` | — | false | Run round-trip verification |
 | `--output` | — | `$TMPDIR/mdocify-export-<id>.md` | Path for exported markdown (with --verify) |
+| `--preset <name>` | — | — | Named bundle of post-upload settings (e.g. `legal`) |
+| `--alignment <value>` | — | — | Paragraph alignment: `start` \| `center` \| `end` \| `justified` \| `none` |
+| `--font <family>` | — | — | Font family applied document-wide (e.g. `"Open Sans"`) |
+| `--font-size <pt>` | — | — | Font size in points |
 
 ## Examples
 
@@ -43,7 +47,24 @@ npx mdocify convert README.md --title "Project Documentation"
 
 # With round-trip verification
 npx mdocify convert README.md --verify --output exported.md
+
+# Apply the "legal" preset (justified + Open Sans 11pt) to an existing doc
+npx mdocify convert contract.md --document-id <id> --preset legal
+
+# Override a preset value
+npx mdocify convert contract.md --preset legal --font-size 12
 ```
+
+## Presets
+
+Presets are named bundles of post-upload settings defined in `src/presets.ts` of the package.
+The skill only references presets by name; execution happens inside mdocify — no wrapping shell logic required.
+
+| Preset | What it sets | Typical use |
+|--------|--------------|-------------|
+| `legal` | Alignment `JUSTIFIED`; per-heading Open Sans (H1 20 / H2 16 / H3 14 / H4 12 / H5 11 / H6 11 pt); NORMAL_TEXT Open Sans 11 pt | Contracts, acts, offers |
+
+Explicit `--alignment` / `--font` / `--font-size` flags override values from the preset.
 
 ## Round-trip Verification
 

--- a/src/executor/chunker.ts
+++ b/src/executor/chunker.ts
@@ -1,6 +1,6 @@
 import type { BatchRequest } from '../types/google-docs.js';
 
-const MAX_REQUESTS_PER_BATCH = 1000;
+export const MAX_REQUESTS_PER_BATCH = 1000;
 
 function isInsertionRequest(req: BatchRequest): boolean {
   return 'insertText' in req || 'insertTable' in req || 'insertInlineImage' in req || 'insertSectionBreak' in req;

--- a/src/executor/native.ts
+++ b/src/executor/native.ts
@@ -129,6 +129,9 @@ function collectParagraphRanges(content: unknown[]): ParagraphRange[] {
   const walk = (elems: unknown[]): void => {
     for (const e of elems as any[]) {
       if (e?.paragraph) {
+        // A structural element without numeric indices can't yield a valid range —
+        // skip it so no NaN reaches later arithmetic or request construction.
+        if (typeof e.startIndex !== 'number' || typeof e.endIndex !== 'number') continue;
         const nst = e.paragraph.paragraphStyle?.namedStyleType ?? 'NORMAL_TEXT';
         out.push({ start: e.startIndex, end: e.endIndex, namedStyleType: nst });
       } else if (e?.table) {

--- a/src/executor/native.ts
+++ b/src/executor/native.ts
@@ -104,47 +104,18 @@ export async function cleanupFiles(...paths: string[]): Promise<void> {
 
 export type Alignment = 'START' | 'CENTER' | 'END' | 'JUSTIFIED';
 
-async function getBodyEndIndex(documentId: string): Promise<number> {
-  const raw = await gws(
-    'docs', 'documents', 'get',
-    '--params', JSON.stringify({ documentId }),
-  );
-  const doc = parseResponse(raw);
-  const content = doc?.body?.content ?? [];
-  const last = content[content.length - 1];
-  return last?.endIndex ?? 1;
-}
-
-export async function applyAlignment(documentId: string, alignment: Alignment): Promise<void> {
-  const end = await getBodyEndIndex(documentId);
-  if (end <= 1) return;
-
-  const body = {
-    requests: [
-      {
-        updateParagraphStyle: {
-          range: { startIndex: 1, endIndex: end - 1 },
-          paragraphStyle: { alignment },
-          fields: 'alignment',
-        },
-      },
-    ],
-  };
-
-  const raw = await gws(
-    'docs', 'documents', 'batchUpdate',
-    '--params', JSON.stringify({ documentId }),
-    '--json', JSON.stringify(body),
-  );
-  parseResponse(raw);
-}
-
 export interface TextStyleOptions {
   fontFamily?: string;
   fontSize?: number;
 }
 
 export type NamedStyleMap = Partial<Record<string, TextStyleOptions>>;
+
+export interface FormattingOptions {
+  alignment?: Alignment;
+  namedStyles?: NamedStyleMap;
+  textStyle?: TextStyleOptions;
+}
 
 interface ParagraphRange {
   start: number;
@@ -193,69 +164,58 @@ function buildTextStyleRequest(style: TextStyleOptions, start: number, end: numb
   };
 }
 
-export async function applyNamedStyles(documentId: string, map: NamedStyleMap): Promise<void> {
+/**
+ * Apply alignment, per-namedStyle text overrides and a document-wide text style
+ * in a single pass: one `documents.get` to resolve ranges, one `batchUpdate` to
+ * apply every request. Requests are ordered alignment → namedStyles → textStyle,
+ * so an explicit document-wide `textStyle` wins over `namedStyles` on overlap
+ * (last write in a batchUpdate takes precedence).
+ */
+export async function applyFormatting(documentId: string, opts: FormattingOptions): Promise<void> {
   const raw = await gws(
     'docs', 'documents', 'get',
     '--params', JSON.stringify({ documentId }),
   );
   const doc = parseResponse(raw);
-  const paragraphs = collectParagraphRanges(doc?.body?.content ?? []);
+  const content = doc?.body?.content ?? [];
+  const last = content[content.length - 1];
+  const end = last?.endIndex ?? 1;
 
   const requests: unknown[] = [];
-  for (const p of paragraphs) {
-    const style = map[p.namedStyleType];
-    if (!style) continue;
-    // For heading-style paragraphs the trailing newline can carry run style from the
-    // next paragraph. Trim endIndex by 1 when the range is longer than one char.
-    const end = p.end - p.start > 1 ? p.end - 1 : p.end;
-    const req = buildTextStyleRequest(style, p.start, end);
+
+  if (opts.alignment && end > 2) {
+    requests.push({
+      updateParagraphStyle: {
+        range: { startIndex: 1, endIndex: end - 1 },
+        paragraphStyle: { alignment: opts.alignment },
+        fields: 'alignment',
+      },
+    });
+  }
+
+  if (opts.namedStyles) {
+    for (const p of collectParagraphRanges(content)) {
+      const style = opts.namedStyles[p.namedStyleType];
+      if (!style) continue;
+      // For heading-style paragraphs the trailing newline can carry run style from the
+      // next paragraph. Trim endIndex by 1 when the range is longer than one char.
+      const pEnd = p.end - p.start > 1 ? p.end - 1 : p.end;
+      const req = buildTextStyleRequest(style, p.start, pEnd);
+      if (req) requests.push(req);
+    }
+  }
+
+  if (opts.textStyle && end > 2) {
+    const req = buildTextStyleRequest(opts.textStyle, 1, end - 1);
     if (req) requests.push(req);
   }
+
   if (requests.length === 0) return;
 
-  const body = { requests };
   const raw2 = await gws(
     'docs', 'documents', 'batchUpdate',
     '--params', JSON.stringify({ documentId }),
-    '--json', JSON.stringify(body),
+    '--json', JSON.stringify({ requests }),
   );
   parseResponse(raw2);
-}
-
-export async function applyTextStyle(documentId: string, style: TextStyleOptions): Promise<void> {
-  const end = await getBodyEndIndex(documentId);
-  if (end <= 1) return;
-
-  const textStyle: Record<string, unknown> = {};
-  const fields: string[] = [];
-
-  if (style.fontFamily) {
-    textStyle.weightedFontFamily = { fontFamily: style.fontFamily };
-    fields.push('weightedFontFamily');
-  }
-  if (style.fontSize) {
-    textStyle.fontSize = { magnitude: style.fontSize, unit: 'PT' };
-    fields.push('fontSize');
-  }
-
-  if (fields.length === 0) return;
-
-  const body = {
-    requests: [
-      {
-        updateTextStyle: {
-          range: { startIndex: 1, endIndex: end - 1 },
-          textStyle,
-          fields: fields.join(','),
-        },
-      },
-    ],
-  };
-
-  const raw = await gws(
-    'docs', 'documents', 'batchUpdate',
-    '--params', JSON.stringify({ documentId }),
-    '--json', JSON.stringify(body),
-  );
-  parseResponse(raw);
 }

--- a/src/executor/native.ts
+++ b/src/executor/native.ts
@@ -144,6 +144,7 @@ function collectParagraphRanges(content: unknown[]): ParagraphRange[] {
 }
 
 function buildTextStyleRequest(style: TextStyleOptions, start: number, end: number): unknown | null {
+  if (start >= end) return null;
   const textStyle: Record<string, unknown> = {};
   const fields: string[] = [];
   if (style.fontFamily) {

--- a/src/executor/native.ts
+++ b/src/executor/native.ts
@@ -60,6 +60,17 @@ export async function exportAsHtml(fileId: string, outputPath: string): Promise<
   );
 }
 
+export async function exportAsDocx(fileId: string, outputPath: string): Promise<void> {
+  await gws(
+    'drive', 'files', 'export',
+    '--params', JSON.stringify({
+      fileId,
+      mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    }),
+    '-o', outputPath,
+  );
+}
+
 export async function exportAsMarkdown(fileId: string, outputPath: string): Promise<void> {
   await gws(
     'drive', 'files', 'export',
@@ -89,4 +100,162 @@ export async function cleanupFiles(...paths: string[]): Promise<void> {
   for (const p of paths) {
     try { await unlink(p); } catch { /* ignore */ }
   }
+}
+
+export type Alignment = 'START' | 'CENTER' | 'END' | 'JUSTIFIED';
+
+async function getBodyEndIndex(documentId: string): Promise<number> {
+  const raw = await gws(
+    'docs', 'documents', 'get',
+    '--params', JSON.stringify({ documentId }),
+  );
+  const doc = parseResponse(raw);
+  const content = doc?.body?.content ?? [];
+  const last = content[content.length - 1];
+  return last?.endIndex ?? 1;
+}
+
+export async function applyAlignment(documentId: string, alignment: Alignment): Promise<void> {
+  const end = await getBodyEndIndex(documentId);
+  if (end <= 1) return;
+
+  const body = {
+    requests: [
+      {
+        updateParagraphStyle: {
+          range: { startIndex: 1, endIndex: end - 1 },
+          paragraphStyle: { alignment },
+          fields: 'alignment',
+        },
+      },
+    ],
+  };
+
+  const raw = await gws(
+    'docs', 'documents', 'batchUpdate',
+    '--params', JSON.stringify({ documentId }),
+    '--json', JSON.stringify(body),
+  );
+  parseResponse(raw);
+}
+
+export interface TextStyleOptions {
+  fontFamily?: string;
+  fontSize?: number;
+}
+
+export type NamedStyleMap = Partial<Record<string, TextStyleOptions>>;
+
+interface ParagraphRange {
+  start: number;
+  end: number;
+  namedStyleType: string;
+}
+
+function collectParagraphRanges(content: unknown[]): ParagraphRange[] {
+  const out: ParagraphRange[] = [];
+  const walk = (elems: unknown[]): void => {
+    for (const e of elems as any[]) {
+      if (e?.paragraph) {
+        const nst = e.paragraph.paragraphStyle?.namedStyleType ?? 'NORMAL_TEXT';
+        out.push({ start: e.startIndex, end: e.endIndex, namedStyleType: nst });
+      } else if (e?.table) {
+        for (const row of e.table.tableRows ?? []) {
+          for (const cell of row.tableCells ?? []) {
+            walk(cell.content ?? []);
+          }
+        }
+      }
+    }
+  };
+  walk(content);
+  return out;
+}
+
+function buildTextStyleRequest(style: TextStyleOptions, start: number, end: number): unknown | null {
+  const textStyle: Record<string, unknown> = {};
+  const fields: string[] = [];
+  if (style.fontFamily) {
+    textStyle.weightedFontFamily = { fontFamily: style.fontFamily };
+    fields.push('weightedFontFamily');
+  }
+  if (style.fontSize) {
+    textStyle.fontSize = { magnitude: style.fontSize, unit: 'PT' };
+    fields.push('fontSize');
+  }
+  if (fields.length === 0) return null;
+  return {
+    updateTextStyle: {
+      range: { startIndex: start, endIndex: end },
+      textStyle,
+      fields: fields.join(','),
+    },
+  };
+}
+
+export async function applyNamedStyles(documentId: string, map: NamedStyleMap): Promise<void> {
+  const raw = await gws(
+    'docs', 'documents', 'get',
+    '--params', JSON.stringify({ documentId }),
+  );
+  const doc = parseResponse(raw);
+  const paragraphs = collectParagraphRanges(doc?.body?.content ?? []);
+
+  const requests: unknown[] = [];
+  for (const p of paragraphs) {
+    const style = map[p.namedStyleType];
+    if (!style) continue;
+    // For heading-style paragraphs the trailing newline can carry run style from the
+    // next paragraph. Trim endIndex by 1 when the range is longer than one char.
+    const end = p.end - p.start > 1 ? p.end - 1 : p.end;
+    const req = buildTextStyleRequest(style, p.start, end);
+    if (req) requests.push(req);
+  }
+  if (requests.length === 0) return;
+
+  const body = { requests };
+  const raw2 = await gws(
+    'docs', 'documents', 'batchUpdate',
+    '--params', JSON.stringify({ documentId }),
+    '--json', JSON.stringify(body),
+  );
+  parseResponse(raw2);
+}
+
+export async function applyTextStyle(documentId: string, style: TextStyleOptions): Promise<void> {
+  const end = await getBodyEndIndex(documentId);
+  if (end <= 1) return;
+
+  const textStyle: Record<string, unknown> = {};
+  const fields: string[] = [];
+
+  if (style.fontFamily) {
+    textStyle.weightedFontFamily = { fontFamily: style.fontFamily };
+    fields.push('weightedFontFamily');
+  }
+  if (style.fontSize) {
+    textStyle.fontSize = { magnitude: style.fontSize, unit: 'PT' };
+    fields.push('fontSize');
+  }
+
+  if (fields.length === 0) return;
+
+  const body = {
+    requests: [
+      {
+        updateTextStyle: {
+          range: { startIndex: 1, endIndex: end - 1 },
+          textStyle,
+          fields: fields.join(','),
+        },
+      },
+    ],
+  };
+
+  const raw = await gws(
+    'docs', 'documents', 'batchUpdate',
+    '--params', JSON.stringify({ documentId }),
+    '--json', JSON.stringify(body),
+  );
+  parseResponse(raw);
 }

--- a/src/executor/native.ts
+++ b/src/executor/native.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { unlink } from 'node:fs/promises';
+import { MAX_REQUESTS_PER_BATCH } from './chunker.js';
 
 const exec = promisify(execFile);
 
@@ -213,10 +214,17 @@ export async function applyFormatting(documentId: string, opts: FormattingOption
 
   if (requests.length === 0) return;
 
-  const raw2 = await gws(
-    'docs', 'documents', 'batchUpdate',
-    '--params', JSON.stringify({ documentId }),
-    '--json', JSON.stringify({ requests }),
-  );
-  parseResponse(raw2);
+  // A large document can yield one updateTextStyle per paragraph, which may exceed
+  // the Docs batchUpdate request limit. Split into ordered chunks. All requests here
+  // are style updates (no insertions), so sequential chunks preserve precedence —
+  // the document-wide textStyle, pushed last, still lands in the final chunk.
+  for (let i = 0; i < requests.length; i += MAX_REQUESTS_PER_BATCH) {
+    const chunk = requests.slice(i, i + MAX_REQUESTS_PER_BATCH);
+    const raw2 = await gws(
+      'docs', 'documents', 'batchUpdate',
+      '--params', JSON.stringify({ documentId }),
+      '--json', JSON.stringify({ requests: chunk }),
+    );
+    parseResponse(raw2);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,7 @@ import {
   updateWithUpload,
   deleteFile,
   cleanupFiles,
-  applyAlignment,
-  applyTextStyle,
-  applyNamedStyles,
+  applyFormatting,
 } from './executor/native.js';
 import { resolvePreset } from './presets.js';
 import { diffMarkdown } from './roundtrip/diff.js';
@@ -67,14 +65,13 @@ export async function convert(
   const fontSize = options.fontSize ?? preset.fontSize;
   const namedStyles = options.namedStyles ?? preset.namedStyles;
 
-  if (alignment !== 'none') {
-    await applyAlignment(documentId, ALIGNMENT_MAP[alignment]);
-  }
-  if (namedStyles) {
-    await applyNamedStyles(documentId, namedStyles);
-  }
-  if (fontFamily || fontSize) {
-    await applyTextStyle(documentId, { fontFamily, fontSize });
+  const textStyle = fontFamily || fontSize ? { fontFamily, fontSize } : undefined;
+  if (alignment !== 'none' || namedStyles || textStyle) {
+    await applyFormatting(documentId, {
+      alignment: alignment !== 'none' ? ALIGNMENT_MAP[alignment] : undefined,
+      namedStyles,
+      textStyle,
+    });
   }
 
   const url = `https://docs.google.com/document/d/${documentId}/edit`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,15 +4,26 @@ import path from 'node:path';
 import {
   uploadFile,
   copyAsGoogleDoc,
-  exportAsHtml,
+  exportAsDocx,
   exportAsMarkdown,
   updateWithUpload,
   deleteFile,
   cleanupFiles,
+  applyAlignment,
+  applyTextStyle,
+  applyNamedStyles,
 } from './executor/native.js';
+import { resolvePreset } from './presets.js';
 import { diffMarkdown } from './roundtrip/diff.js';
 import { formatReport } from './roundtrip/report.js';
-import type { ConvertOptions, ConvertResult, LossReport } from './types/options.js';
+import type { Alignment, ConvertOptions, ConvertResult, LossReport } from './types/options.js';
+
+const ALIGNMENT_MAP: Record<Exclude<Alignment, 'none'>, 'START' | 'CENTER' | 'END' | 'JUSTIFIED'> = {
+  start: 'START',
+  center: 'CENTER',
+  end: 'END',
+  justified: 'JUSTIFIED',
+};
 
 export async function convert(
   markdownPath: string,
@@ -27,16 +38,17 @@ export async function convert(
 
   try {
     if (options.documentId) {
-      // Overwrite existing: copy → export html → update target → cleanup
+      // Overwrite existing: copy → export docx → update target → cleanup.
+      // DOCX preserves bullet lists through the Drive re-import, HTML does not.
       const tempDocId = await copyAsGoogleDoc(mdFileId, `mdocify-temp-${Date.now()}`);
-      const htmlPath = path.join(os.tmpdir(), `mdocify-${Date.now()}.html`);
+      const docxPath = path.join(os.tmpdir(), `mdocify-${Date.now()}.docx`);
 
       try {
-        await exportAsHtml(tempDocId, htmlPath);
-        await updateWithUpload(options.documentId, htmlPath);
+        await exportAsDocx(tempDocId, docxPath);
+        await updateWithUpload(options.documentId, docxPath);
       } finally {
         await deleteFile(tempDocId).catch(() => {});
-        await cleanupFiles(htmlPath);
+        await cleanupFiles(docxPath);
       }
 
       documentId = options.documentId;
@@ -46,6 +58,23 @@ export async function convert(
     }
   } finally {
     await deleteFile(mdFileId).catch(() => {});
+  }
+
+  // Resolve preset (if any) and let explicit options win
+  const preset = options.preset ? resolvePreset(options.preset) : {};
+  const alignment: Alignment = options.alignment ?? preset.alignment ?? 'none';
+  const fontFamily = options.fontFamily ?? preset.fontFamily;
+  const fontSize = options.fontSize ?? preset.fontSize;
+  const namedStyles = options.namedStyles ?? preset.namedStyles;
+
+  if (alignment !== 'none') {
+    await applyAlignment(documentId, ALIGNMENT_MAP[alignment]);
+  }
+  if (namedStyles) {
+    await applyNamedStyles(documentId, namedStyles);
+  }
+  if (fontFamily || fontSize) {
+    await applyTextStyle(documentId, { fontFamily, fontSize });
   }
 
   const url = `https://docs.google.com/document/d/${documentId}/edit`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,10 @@ export async function convert(
   const title = options.title ?? path.basename(markdownPath, '.md');
   let documentId: string;
 
+  // Resolve preset up front so an unknown name fails before any document
+  // side effects (create/overwrite) happen.
+  const preset = options.preset ? resolvePreset(options.preset) : {};
+
   // Upload md to Google Drive
   const mdFileId = await uploadFile(markdownPath, `mdocify-temp-${Date.now()}.md`);
 
@@ -58,8 +62,7 @@ export async function convert(
     await deleteFile(mdFileId).catch(() => {});
   }
 
-  // Resolve preset (if any) and let explicit options win
-  const preset = options.preset ? resolvePreset(options.preset) : {};
+  // Explicit options win over preset values
   const alignment: Alignment = options.alignment ?? preset.alignment ?? 'none';
   const fontFamily = options.fontFamily ?? preset.fontFamily;
   const fontSize = options.fontSize ?? preset.fontSize;

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,0 +1,32 @@
+import type { Alignment, NamedStyleMap } from './types/options.js';
+
+export interface Preset {
+  alignment?: Alignment;
+  fontFamily?: string;
+  fontSize?: number;
+  namedStyles?: NamedStyleMap;
+}
+
+export const PRESETS: Record<string, Preset> = {
+  legal: {
+    alignment: 'justified',
+    namedStyles: {
+      NORMAL_TEXT: { fontFamily: 'Open Sans', fontSize: 11 },
+      HEADING_1: { fontFamily: 'Open Sans', fontSize: 20 },
+      HEADING_2: { fontFamily: 'Open Sans', fontSize: 16 },
+      HEADING_3: { fontFamily: 'Open Sans', fontSize: 14 },
+      HEADING_4: { fontFamily: 'Open Sans', fontSize: 12 },
+      HEADING_5: { fontFamily: 'Open Sans', fontSize: 11 },
+      HEADING_6: { fontFamily: 'Open Sans', fontSize: 11 },
+    },
+  },
+};
+
+export function resolvePreset(name: string): Preset {
+  const p = PRESETS[name];
+  if (!p) {
+    const names = Object.keys(PRESETS).join(', ');
+    throw new Error(`Unknown preset "${name}". Available: ${names}`);
+  }
+  return p;
+}

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,8 +1,28 @@
+export type Alignment = 'start' | 'center' | 'end' | 'justified' | 'none';
+
+export interface TextStyleSpec {
+  fontFamily?: string;
+  fontSize?: number;
+}
+
+/** Map from `namedStyleType` (e.g. "NORMAL_TEXT", "HEADING_1") to a text style override. */
+export type NamedStyleMap = Partial<Record<string, TextStyleSpec>>;
+
 export interface ConvertOptions {
   title?: string;
   documentId?: string;
   verify?: boolean;
   output?: string;
+  /** Preset name — applies a bundle of post-upload settings (see src/presets.ts). Explicit options below win over the preset. */
+  preset?: string;
+  /** Paragraph alignment applied after upload. `'none'` skips. */
+  alignment?: Alignment;
+  /** Font family applied as a single run-style override to the whole document. */
+  fontFamily?: string;
+  /** Font size (pt) applied as a single run-style override to the whole document. */
+  fontSize?: number;
+  /** Per-namedStyle text overrides — respects heading sizes, only changes the style you actually target. */
+  namedStyles?: NamedStyleMap;
 }
 
 export interface ConvertResult {

--- a/tests/presets.test.ts
+++ b/tests/presets.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { PRESETS, resolvePreset } from '../src/presets.js';
+
+describe('resolvePreset', () => {
+  it('returns the requested preset', () => {
+    expect(resolvePreset('legal')).toBe(PRESETS.legal);
+  });
+
+  it('throws on an unknown preset and lists available names', () => {
+    expect(() => resolvePreset('nope')).toThrow(/Unknown preset "nope"/);
+    expect(() => resolvePreset('nope')).toThrow(/legal/);
+  });
+});
+
+describe('legal preset', () => {
+  const legal = PRESETS.legal;
+
+  it('justifies the whole body', () => {
+    expect(legal.alignment).toBe('justified');
+  });
+
+  it('styles NORMAL_TEXT and headings with Open Sans', () => {
+    expect(legal.namedStyles?.NORMAL_TEXT).toEqual({ fontFamily: 'Open Sans', fontSize: 11 });
+    expect(legal.namedStyles?.HEADING_1).toEqual({ fontFamily: 'Open Sans', fontSize: 20 });
+    expect(legal.namedStyles?.HEADING_2).toEqual({ fontFamily: 'Open Sans', fontSize: 16 });
+    expect(legal.namedStyles?.HEADING_3).toEqual({ fontFamily: 'Open Sans', fontSize: 14 });
+  });
+
+  it('does not set a document-wide font override (prefers namedStyles)', () => {
+    expect(legal.fontFamily).toBeUndefined();
+    expect(legal.fontSize).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Что делает

Фича 0.3.0: пресеты и пост-загрузочная стилизация Google Doc, плюс фикс потери маркеров списков при обновлении существующего документа.

## Изменения

- Флаги `--preset` / `--alignment` / `--font` / `--font-size` и реестр пресетов `src/presets.ts` (первый пресет — `legal`)
- Executor-хелперы: `applyAlignment`, `applyTextStyle`, `applyNamedStyles`, `exportAsDocx`
- Путь обновления `--document-id` переведён с HTML- на **DOCX-посредник** — HTML при реимпорте терял буллеты, DOCX сохраняет
- Bump до 0.3.0, обновлены CHANGELOG / README / SKILL

## Проверка

- `tsc --noEmit` — чисто
- `npm test` — 41/41 зелёные

## Известные хвосты (не блокеры)

- Нет unit-тестов на пресеты/стилизацию — планирую отдельным PR

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added preset-based formatting with a built-in `legal` preset.
  - Added alignment and font overrides, plus targeted named-style styling support.
  - Added new CLI flags (`--preset`, `--alignment`, `--font`, `--font-size`, `--verify`) to apply these during conversion.
- **Bug Fixes**
  - Improved existing-document updates so unordered lists/bullets keep their markers.
- **Documentation**
  - Expanded usage guides with preset tables, common flags, and override behavior notes.
- **Refactor**
  - Switched overwrite/update handling to a DOCX-based flow for more reliable list preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->